### PR TITLE
fix: deprecate npm bin

### DIFF
--- a/lint-build.sh
+++ b/lint-build.sh
@@ -4,7 +4,6 @@ DIRNAME=$(dirname "$0")
 CONFIG="$DIRNAME/.eslintrc.json"
 DEBUG=false
 FIX=false
-NPM_BIN=$(npm bin);
 
 while getopts "c:d:f:s:" flag
 do
@@ -33,7 +32,7 @@ if [ "$DEBUG" = true ]; then
   printf "[DEBUG] FIX: %s\n" "$FIX"
   printf "[DEBUG] SRC: %s\n" "$SRC"
 elif [ "$FIX" = true ]; then
-  "$NPM_BIN"/eslint "${SRC:-src/**/*.ts}" --ext .js,.jsx,.ts,.tsx --config "$CONFIG" --fix
+  npm x -- eslint "${SRC:-src/**/*.ts}" --ext .js,.jsx,.ts,.tsx --config "$CONFIG" --fix
 else
-  "$NPM_BIN"/eslint "${SRC:-src/**/*.ts}" --ext .js,.jsx,.ts,.tsx --config "$CONFIG"
+  npm x -- eslint "${SRC:-src/**/*.ts}" --ext .js,.jsx,.ts,.tsx --config "$CONFIG"
 fi

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
-NPM_BIN=$(npm bin)
 NPM_ROOT=$(npm root)
 
-"$NPM_BIN"/package-check && \
-"$NPM_BIN"/nano-staged --config "$NPM_ROOT"/@reallyland/tools/.nano-staged.json && \
-"$NPM_BIN"/tsc --noEmit
+npm x -- package-check && \
+npm x -- nano-staged --config "$NPM_ROOT"/@reallyland/tools/.nano-staged.json && \
+npm x -- tsc --noEmit

--- a/simple-git-hooks.sh
+++ b/simple-git-hooks.sh
@@ -2,7 +2,6 @@
 
 DIRNAME=$(dirname "$0")
 CONFIG="$DIRNAME/.base.simple-git-hooks.json"
-NPM_BIN=$(npm bin)
 
 # NOTE(motss): This is a workaround for the fact that the `simple-git-hooks` does not support
 # custom configuration file.
@@ -11,7 +10,7 @@ NPM_BIN=$(npm bin)
 cp "$CONFIG" ./.simple-git-hooks.json
 
 # 2. Run the `simple-git-hooks`
-"$NPM_BIN"/simple-git-hooks
+npm x -- simple-git-hooks
 
 # 3. Remove the configuration file from `pwd`
 rm -rf ./.simple-git-hooks.json


### PR DESCRIPTION
## Changes

* deprecate the use of `npm bin` as of `npm@9.x`