### PR TITLE
ci: update publish script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,8 @@ env:
   NPM_VERSION: 0.0.0
 
 jobs:
-  build:
+  publish:
+    if: "contains(github.event.head_commit.message, 'chore(release)')"
     name: ${{ matrix.os }} ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120


### PR DESCRIPTION
## Changes

* update publish script to only run when commit message contains `chore(release)` when pushing to `main` branch