### PR TITLE
fix: update linter to improve no-unused-vars rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,7 @@
     "@typescript-eslint/no-unused-vars": [
       "error", {
         "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
         "varsIgnorePattern": "^_"
       }
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,9 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/changelog-github": "*",
-        "@changesets/cli": "*"
+        "@commitlint/config-conventional": "*",
+        "@typescript-eslint/eslint-plugin": "*",
+        "@typescript-eslint/parser": "*"
       },
       "engines": {
         "node": ">= 16.x",
@@ -20,10 +21,10 @@
       "optionalDependencies": {
         "@changesets/changelog-github": "^0.4.8",
         "@changesets/cli": "^2.26.0",
-        "@commitlint/config-conventional": "^17.4.2",
+        "@commitlint/config-conventional": "^17.4.4",
         "@skypack/package-check": "^0.2.2",
-        "@typescript-eslint/eslint-plugin": "^5.51.0",
-        "@typescript-eslint/parser": "^5.51.0",
+        "@typescript-eslint/eslint-plugin": "^5.53.0",
+        "@typescript-eslint/parser": "^5.53.0",
         "eslint": "^8.34.0",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-promise": "^6.1.1",
@@ -767,9 +768,9 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.4.2.tgz",
-      "integrity": "sha512-JVo1moSj5eDMoql159q8zKCU8lkOhQ+b23Vl3LVVrS6PXDLQIELnJ34ChQmFVbBdSSRNAbbXnRDhosFU+wnuHw==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.4.4.tgz",
+      "integrity": "sha512-u6ztvxqzi6NuhrcEDR7a+z0yrh11elY66nRrQIpqsqW6sZmpxYkDLtpRH8jRML+mmxYQ8s4qqF06Q/IQx5aJeQ==",
       "optional": true,
       "dependencies": {
         "conventional-changelog-conventionalcommits": "^5.0.0"
@@ -988,14 +989,14 @@
       "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.51.0.tgz",
-      "integrity": "sha512-wcAwhEWm1RgNd7dxD/o+nnLW8oH+6RK1OGnmbmkj/GGoDPV1WWMVP0FXYQBivKHdwM1pwii3bt//RC62EriIUQ==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.53.0.tgz",
+      "integrity": "sha512-alFpFWNucPLdUOySmXCJpzr6HKC3bu7XooShWM+3w/EL6J2HIoB2PFxpLnq4JauWVk6DiVeNKzQlFEaE+X9sGw==",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.51.0",
-        "@typescript-eslint/type-utils": "5.51.0",
-        "@typescript-eslint/utils": "5.51.0",
+        "@typescript-eslint/scope-manager": "5.53.0",
+        "@typescript-eslint/type-utils": "5.53.0",
+        "@typescript-eslint/utils": "5.53.0",
         "debug": "^4.3.4",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
@@ -1022,14 +1023,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.51.0.tgz",
-      "integrity": "sha512-fEV0R9gGmfpDeRzJXn+fGQKcl0inIeYobmmUWijZh9zA7bxJ8clPhV9up2ZQzATxAiFAECqPQyMDB4o4B81AaA==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.53.0.tgz",
+      "integrity": "sha512-MKBw9i0DLYlmdOb3Oq/526+al20AJZpANdT6Ct9ffxcV8nKCHz63t/S0IhlTFNsBIHJv+GY5SFJ0XfqVeydQrQ==",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.51.0",
-        "@typescript-eslint/types": "5.51.0",
-        "@typescript-eslint/typescript-estree": "5.51.0",
+        "@typescript-eslint/scope-manager": "5.53.0",
+        "@typescript-eslint/types": "5.53.0",
+        "@typescript-eslint/typescript-estree": "5.53.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1049,13 +1050,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.51.0.tgz",
-      "integrity": "sha512-gNpxRdlx5qw3yaHA0SFuTjW4rxeYhpHxt491PEcKF8Z6zpq0kMhe0Tolxt0qjlojS+/wArSDlj/LtE69xUJphQ==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.53.0.tgz",
+      "integrity": "sha512-Opy3dqNsp/9kBBeCPhkCNR7fmdSQqA+47r21hr9a14Bx0xnkElEQmhoHga+VoaoQ6uDHjDKmQPIYcUcKJifS7w==",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.51.0",
-        "@typescript-eslint/visitor-keys": "5.51.0"
+        "@typescript-eslint/types": "5.53.0",
+        "@typescript-eslint/visitor-keys": "5.53.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1066,13 +1067,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.51.0.tgz",
-      "integrity": "sha512-QHC5KKyfV8sNSyHqfNa0UbTbJ6caB8uhcx2hYcWVvJAZYJRBo5HyyZfzMdRx8nvS+GyMg56fugMzzWnojREuQQ==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.53.0.tgz",
+      "integrity": "sha512-HO2hh0fmtqNLzTAme/KnND5uFNwbsdYhCZghK2SoxGp3Ifn2emv+hi0PBUjzzSh0dstUIFqOj3bp0AwQlK4OWw==",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.51.0",
-        "@typescript-eslint/utils": "5.51.0",
+        "@typescript-eslint/typescript-estree": "5.53.0",
+        "@typescript-eslint/utils": "5.53.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -1093,9 +1094,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.51.0.tgz",
-      "integrity": "sha512-SqOn0ANn/v6hFn0kjvLwiDi4AzR++CBZz0NV5AnusT2/3y32jdc0G4woXPWHCumWtUXZKPAS27/9vziSsC9jnw==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.53.0.tgz",
+      "integrity": "sha512-5kcDL9ZUIP756K6+QOAfPkigJmCPHcLN7Zjdz76lQWWDdzfOhZDTj1irs6gPBKiXx5/6O3L0+AvupAut3z7D2A==",
       "optional": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1106,13 +1107,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.51.0.tgz",
-      "integrity": "sha512-TSkNupHvNRkoH9FMA3w7TazVFcBPveAAmb7Sz+kArY6sLT86PA5Vx80cKlYmd8m3Ha2SwofM1KwraF24lM9FvA==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.53.0.tgz",
+      "integrity": "sha512-eKmipH7QyScpHSkhbptBBYh9v8FxtngLquq292YTEQ1pxVs39yFBlLC1xeIZcPPz1RWGqb7YgERJRGkjw8ZV7w==",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.51.0",
-        "@typescript-eslint/visitor-keys": "5.51.0",
+        "@typescript-eslint/types": "5.53.0",
+        "@typescript-eslint/visitor-keys": "5.53.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1133,16 +1134,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.51.0.tgz",
-      "integrity": "sha512-76qs+5KWcaatmwtwsDJvBk4H76RJQBFe+Gext0EfJdC3Vd2kpY2Pf//OHHzHp84Ciw0/rYoGTDnIAr3uWhhJYw==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.53.0.tgz",
+      "integrity": "sha512-VUOOtPv27UNWLxFwQK/8+7kvxVC+hPHNsJjzlJyotlaHjLSIgOCKj9I0DBUjwOOA64qjBwx5afAPjksqOxMO0g==",
       "optional": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.51.0",
-        "@typescript-eslint/types": "5.51.0",
-        "@typescript-eslint/typescript-estree": "5.51.0",
+        "@typescript-eslint/scope-manager": "5.53.0",
+        "@typescript-eslint/types": "5.53.0",
+        "@typescript-eslint/typescript-estree": "5.53.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
@@ -1159,12 +1160,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.51.0.tgz",
-      "integrity": "sha512-Oh2+eTdjHjOFjKA27sxESlA87YPSOJafGCR0md5oeMdh1ZcCfAGCIOL216uTBAkAIptvLIfKQhl7lHxMJet4GQ==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.53.0.tgz",
+      "integrity": "sha512-JqNLnX3leaHFZEN0gCh81sIvgrp/2GOACZNgO4+Tkf64u51kTpAyWFOY8XHx8XuXr3N2C9zgPPHtcpMg6z1g0w==",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.51.0",
+        "@typescript-eslint/types": "5.53.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -5675,9 +5676,9 @@
       }
     },
     "@commitlint/config-conventional": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.4.2.tgz",
-      "integrity": "sha512-JVo1moSj5eDMoql159q8zKCU8lkOhQ+b23Vl3LVVrS6PXDLQIELnJ34ChQmFVbBdSSRNAbbXnRDhosFU+wnuHw==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.4.4.tgz",
+      "integrity": "sha512-u6ztvxqzi6NuhrcEDR7a+z0yrh11elY66nRrQIpqsqW6sZmpxYkDLtpRH8jRML+mmxYQ8s4qqF06Q/IQx5aJeQ==",
       "optional": true,
       "requires": {
         "conventional-changelog-conventionalcommits": "^5.0.0"
@@ -5863,14 +5864,14 @@
       "optional": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.51.0.tgz",
-      "integrity": "sha512-wcAwhEWm1RgNd7dxD/o+nnLW8oH+6RK1OGnmbmkj/GGoDPV1WWMVP0FXYQBivKHdwM1pwii3bt//RC62EriIUQ==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.53.0.tgz",
+      "integrity": "sha512-alFpFWNucPLdUOySmXCJpzr6HKC3bu7XooShWM+3w/EL6J2HIoB2PFxpLnq4JauWVk6DiVeNKzQlFEaE+X9sGw==",
       "optional": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.51.0",
-        "@typescript-eslint/type-utils": "5.51.0",
-        "@typescript-eslint/utils": "5.51.0",
+        "@typescript-eslint/scope-manager": "5.53.0",
+        "@typescript-eslint/type-utils": "5.53.0",
+        "@typescript-eslint/utils": "5.53.0",
         "debug": "^4.3.4",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
@@ -5881,53 +5882,53 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.51.0.tgz",
-      "integrity": "sha512-fEV0R9gGmfpDeRzJXn+fGQKcl0inIeYobmmUWijZh9zA7bxJ8clPhV9up2ZQzATxAiFAECqPQyMDB4o4B81AaA==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.53.0.tgz",
+      "integrity": "sha512-MKBw9i0DLYlmdOb3Oq/526+al20AJZpANdT6Ct9ffxcV8nKCHz63t/S0IhlTFNsBIHJv+GY5SFJ0XfqVeydQrQ==",
       "optional": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.51.0",
-        "@typescript-eslint/types": "5.51.0",
-        "@typescript-eslint/typescript-estree": "5.51.0",
+        "@typescript-eslint/scope-manager": "5.53.0",
+        "@typescript-eslint/types": "5.53.0",
+        "@typescript-eslint/typescript-estree": "5.53.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.51.0.tgz",
-      "integrity": "sha512-gNpxRdlx5qw3yaHA0SFuTjW4rxeYhpHxt491PEcKF8Z6zpq0kMhe0Tolxt0qjlojS+/wArSDlj/LtE69xUJphQ==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.53.0.tgz",
+      "integrity": "sha512-Opy3dqNsp/9kBBeCPhkCNR7fmdSQqA+47r21hr9a14Bx0xnkElEQmhoHga+VoaoQ6uDHjDKmQPIYcUcKJifS7w==",
       "optional": true,
       "requires": {
-        "@typescript-eslint/types": "5.51.0",
-        "@typescript-eslint/visitor-keys": "5.51.0"
+        "@typescript-eslint/types": "5.53.0",
+        "@typescript-eslint/visitor-keys": "5.53.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.51.0.tgz",
-      "integrity": "sha512-QHC5KKyfV8sNSyHqfNa0UbTbJ6caB8uhcx2hYcWVvJAZYJRBo5HyyZfzMdRx8nvS+GyMg56fugMzzWnojREuQQ==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.53.0.tgz",
+      "integrity": "sha512-HO2hh0fmtqNLzTAme/KnND5uFNwbsdYhCZghK2SoxGp3Ifn2emv+hi0PBUjzzSh0dstUIFqOj3bp0AwQlK4OWw==",
       "optional": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.51.0",
-        "@typescript-eslint/utils": "5.51.0",
+        "@typescript-eslint/typescript-estree": "5.53.0",
+        "@typescript-eslint/utils": "5.53.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.51.0.tgz",
-      "integrity": "sha512-SqOn0ANn/v6hFn0kjvLwiDi4AzR++CBZz0NV5AnusT2/3y32jdc0G4woXPWHCumWtUXZKPAS27/9vziSsC9jnw==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.53.0.tgz",
+      "integrity": "sha512-5kcDL9ZUIP756K6+QOAfPkigJmCPHcLN7Zjdz76lQWWDdzfOhZDTj1irs6gPBKiXx5/6O3L0+AvupAut3z7D2A==",
       "optional": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.51.0.tgz",
-      "integrity": "sha512-TSkNupHvNRkoH9FMA3w7TazVFcBPveAAmb7Sz+kArY6sLT86PA5Vx80cKlYmd8m3Ha2SwofM1KwraF24lM9FvA==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.53.0.tgz",
+      "integrity": "sha512-eKmipH7QyScpHSkhbptBBYh9v8FxtngLquq292YTEQ1pxVs39yFBlLC1xeIZcPPz1RWGqb7YgERJRGkjw8ZV7w==",
       "optional": true,
       "requires": {
-        "@typescript-eslint/types": "5.51.0",
-        "@typescript-eslint/visitor-keys": "5.51.0",
+        "@typescript-eslint/types": "5.53.0",
+        "@typescript-eslint/visitor-keys": "5.53.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -5936,28 +5937,28 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.51.0.tgz",
-      "integrity": "sha512-76qs+5KWcaatmwtwsDJvBk4H76RJQBFe+Gext0EfJdC3Vd2kpY2Pf//OHHzHp84Ciw0/rYoGTDnIAr3uWhhJYw==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.53.0.tgz",
+      "integrity": "sha512-VUOOtPv27UNWLxFwQK/8+7kvxVC+hPHNsJjzlJyotlaHjLSIgOCKj9I0DBUjwOOA64qjBwx5afAPjksqOxMO0g==",
       "optional": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.51.0",
-        "@typescript-eslint/types": "5.51.0",
-        "@typescript-eslint/typescript-estree": "5.51.0",
+        "@typescript-eslint/scope-manager": "5.53.0",
+        "@typescript-eslint/types": "5.53.0",
+        "@typescript-eslint/typescript-estree": "5.53.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.51.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.51.0.tgz",
-      "integrity": "sha512-Oh2+eTdjHjOFjKA27sxESlA87YPSOJafGCR0md5oeMdh1ZcCfAGCIOL216uTBAkAIptvLIfKQhl7lHxMJet4GQ==",
+      "version": "5.53.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.53.0.tgz",
+      "integrity": "sha512-JqNLnX3leaHFZEN0gCh81sIvgrp/2GOACZNgO4+Tkf64u51kTpAyWFOY8XHx8XuXr3N2C9zgPPHtcpMg6z1g0w==",
       "optional": true,
       "requires": {
-        "@typescript-eslint/types": "5.51.0",
+        "@typescript-eslint/types": "5.53.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -59,10 +59,10 @@
   "optionalDependencies": {
     "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "^2.26.0",
-    "@commitlint/config-conventional": "^17.4.2",
+    "@commitlint/config-conventional": "^17.4.4",
     "@skypack/package-check": "^0.2.2",
-    "@typescript-eslint/eslint-plugin": "^5.51.0",
-    "@typescript-eslint/parser": "^5.51.0",
+    "@typescript-eslint/eslint-plugin": "^5.53.0",
+    "@typescript-eslint/parser": "^5.53.0",
     "eslint": "^8.34.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-promise": "^6.1.1",


### PR DESCRIPTION
## Changes

1. Update linter config to catch `no-unused-vars` errors in `try...catch`
1. Update dependencies